### PR TITLE
Repaired function of the Enter on Numpad

### DIFF
--- a/src/app/components/input.tsx
+++ b/src/app/components/input.tsx
@@ -14,7 +14,7 @@ export const Input = ({ value, onValueChange, onEnter }: Props) => {
 	};
 
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-		if (e.code === 'Enter') {
+		if (e.code === 'Enter' || e.code === 'NumpadEnter') {
 			e.preventDefault();
 			onEnter();
 		}


### PR DESCRIPTION
## Problem
Enter on Numpad didn't work

Fixes https://github.com/oss-institute/workshop-24-3/issues/3

## Describe your changes
- added condition e.code === 'NumpadEnter'

## Testing
While running the app - add a new item and press the Enter button on Numpad. If you have a laptop without Numpad, you can not test :-)

## Checklist before requesting a review
- [ ] I was guided by the tutor, so it has to be good

